### PR TITLE
Remove "developper" section

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,11 +8,6 @@
     },
     "license": "GPLv3.0",
     "url": "http://libresonic.org",
-    "developper": {
-        "name": "Eugene E. Kashpureff Jr",
-        "email": "eugene@kashpureff.org",
-        "url": "https://eugenekay.com"
-    },
     "maintainer": {
         "name": "massyas",
         "email": "massyas@gmail.com"


### PR DESCRIPTION
The developper came to the chat today saying he receives unwanted emails from our automatic tests because of this section in the manifest. (Not sure why this email is used instead of the 'maintainer' one, I'm guessing that's related to how the email is parsed)

We should remove this so he/she can live in peace :/ Not sure that having this info in the manifest if useful